### PR TITLE
Made required heart level a configurable setting.

### DIFF
--- a/Mod.cs
+++ b/Mod.cs
@@ -11,12 +11,17 @@ namespace ThreeHeartDancePartner
 {
     public class Mod : StardewModdingAPI.Mod
     {
+        internal static Mod Instance { get; private set; }
+        internal protected static ModConfig Config => ModConfig.Instance;
+
         /// <summary>The mod entry point, called after the mod is first loaded.</summary>
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
             Log.Monitor = Monitor;
             helper.Events.Display.MenuChanged += onMenuChanged;
+
+            ModConfig.Load();
         }
 
         /// <summary>Raised after a game menu is opened, closed, or replaced.</summary>
@@ -43,8 +48,9 @@ namespace ThreeHeartDancePartner
                 return;
 
             // replace with accept dialog
-            // The original stuff, only the relationship point check is modified. (1000 -> 750)
-            if (!npc.HasPartnerForDance && Game1.player.getFriendshipLevelForNPC(npc.Name) >= 750)
+            // The original stuff, only the relationship point check is modified. (1000 -> custom hearts * 250)
+            if (!npc.HasPartnerForDance && 
+                Game1.player.getFriendshipLevelForNPC(npc.Name) >= Config.HeartsRequiredForDancePartner * 250)
             {
                 string s = "";
                 switch (npc.Gender)

--- a/Mod.cs
+++ b/Mod.cs
@@ -21,6 +21,7 @@ namespace ThreeHeartDancePartner
             Log.Monitor = Monitor;
             helper.Events.Display.MenuChanged += onMenuChanged;
 
+            Instance = this;
             ModConfig.Load();
         }
 

--- a/ModConfig.cs
+++ b/ModConfig.cs
@@ -1,0 +1,52 @@
+﻿using StardewModdingAPI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ThreeHeartDancePartner
+{
+    public class ModConfig
+    {
+        protected static IModHelper Helper => Mod.Instance.Helper;
+        protected static IMonitor Monitor => Mod.Instance.Monitor;
+        internal static ModConfig Instance { get; private set; }
+        internal static void Load()
+        {
+            Instance = Helper.ReadConfig<ModConfig>();
+        }
+
+        // Config option for dance partner acceptance required heart level
+        public int HeartsRequiredForDancePartner
+        {
+            get 
+            {
+                Monitor.LogOnce($"HeartsRequiredForDancePartner is currently set to [{_heartsRequiredForDancePartner}].\n" +
+                        $"The vanilla game requires 4 hearts. The default for this mod is 3.", LogLevel.Info);
+                return _heartsRequiredForDancePartner; 
+            }
+            set
+            {
+                if (value < 0)
+                {
+                    Monitor.Log($"Invalid config value [{value}] for HeartsRequiredForDancePartner.\n" +
+                        $"You must enter a non-negative integer.\n" +
+                        $"HeartsRequiredForDancePartner has been reset to previous value [{_heartsRequiredForDancePartner}] hearts.", LogLevel.Warn);
+                }
+                else
+                {
+                    _heartsRequiredForDancePartner = value;
+                    if (value >= 10)
+                    {
+                        Monitor.Log($"ARE YOU SURE? Unusual config value [{value}] for HeartsRequiredForDancePartner.\n" +
+                            $"The maximum possible heart level is 10 for villagers, 14 for spouses.\n" +
+                            $"If you're sure, you can safely ignore this message.", LogLevel.Warn);
+                    }
+                }
+            }
+        }
+        private static readonly int _heartsRequiredDefault = 3;
+        private int _heartsRequiredForDancePartner = _heartsRequiredDefault;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # ThreeHeartDancePartner
+This is an update of spacechase0's Three Heart Dance Parter mod, with added config.
+Original README text follows.
+
 This is the source code. Releases can be found at:
 * [My site](http://spacechase0.com/mods/stardew-valley/three-heart-dance-partner/)
 * [Nexus](http://www.nexusmods.com/stardewvalley/mods/500/)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ThreeHeartDancePartner
-This is an update of spacechase0's Three Heart Dance Parter mod, with added config.
+This is an update of spacechase0's Three Heart Dance Partner mod, with added config.
 Original README text follows.
 
 This is the source code. Releases can be found at:

--- a/ThreeHeartDancePartner.csproj
+++ b/ThreeHeartDancePartner.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>net452</TargetFramework>
     <Platforms>x86</Platforms>
     <PlatformTarget>x86</PlatformTarget>
+    <ModFolderName>AnyHeartDancePartner</ModFolderName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Any Heart Dance Partner",
   "Author": "spacechase0 and Jonqora",
-  "Version": "1.1.0-unofficial.1-Jonqora",
+  "Version": "1.1.0-unofficial.2-Jonqora",
   "Description": "Adjust the required heart level for a dance partner at the flower festival.",
   "UniqueID": "ThreeHeartDancePartner",
   "EntryDll": "ThreeHeartDancePartner.dll",

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "Name": "3-heart Dance Partner",
-  "Author": "spacechase0",
-  "Version": "1.0.5",
-  "Description": "Makes you only need 3 hearts for a dance partner at the flower festival.",
+  "Name": "Any Heart Dance Partner",
+  "Author": "spacechase0 and Jonqora",
+  "Version": "1.1.0-unofficial.1-Jonqora",
+  "Description": "Adjust the required heart level for a dance partner at the flower festival.",
   "UniqueID": "ThreeHeartDancePartner",
   "EntryDll": "ThreeHeartDancePartner.dll",
-  "MinimumApiVersion": "2.9.0",
+  "MinimumApiVersion": "3.0.0",
   "UpdateKeys": [ "Nexus:500", "Chucklefish:3767" ],
   "spacechase0": "three-heart-dance-partner"
 }


### PR DESCRIPTION
New ModConfig property HeartsRequiredForDancePartner includes a
custom getter and setter to detect invalid or unikely values, giving
users a helpful warning message in the console.